### PR TITLE
Add pandas to project dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "numpy",
     "ezc3d",
     "lxml",
-    "scipy",
+    "scipy", 
     "pandas",
 ]
 


### PR DESCRIPTION
it was not installed immediately on my env with pip but need in "biobuddy/utils/marker_data.py"
